### PR TITLE
[COOK-1363] Fix user password change on systems not using bash as system shell.

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -25,7 +25,7 @@ action :create do
   unless @smbuser.exists
     pw = new_resource.password
     execute "Create #{new_resource.name}" do
-      command "echo -ne '#{pw}\n#{pw}\n' | smbpasswd -s -a #{new_resource.name}"
+      command "echo '#{pw}\n#{pw}' | smbpasswd -s -a #{new_resource.name}"
     end
     new_resource.updated_by_last_action(true)
   end


### PR DESCRIPTION
Rather attempt to specify newline and escape options to echo, insert the newline in ruby, and rely on the echo newline at the end.
