### PR TITLE
Add ability to select data bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The attributes are used to set up the default values in the smb.conf, and set de
 * `node["samba"]["socket_options"]` - Socket options, default "`TCP_NODELAY`"
 * `node["samba"]["config"]` - Location of Samba configuration, default "/etc/samba/smb.conf".
 * `node["samba"]["log_dir"]` - Location of Samba logs, default "/var/log/samba/%m.log".
+* `node["samba"]["shares_data_bag"]` - the name of the data bag that contains the shares information, default "samba". See `Usage` below.
+* `node["samba"]["users_data_bag"]` - the name of the data bag that contains user details, default "users". See `Usage` below.
 
 Recipes
 =======
@@ -79,7 +81,7 @@ Usage
 
 The `samba::default` recipe includes `samba::client`, which simply installs smbclient package. Remaining information in this section pertains to `samba::server` recipe.
 
-Set attributes as desired in a role, and create a data bag named `samba` with an item called `shares`. Also create a `users` data bag with an item for each user that should have access to samba.
+Set attributes as desired in a role, and create a data bag with an item called `shares`. The default name for the data bag is `samba` but this can be changed by setting `node["samba"]["data_bag"]`. Also create a data bag with an item for each user that should have access to samba. The name of the users data bag defaults to `users` but can be changed by setting `node["samba"]["users_data_bag"]`.
 
 Example data bag item for a single share named `export` in the `shares` item.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,8 @@ default["samba"]["dns_proxy"] = "no"
 default["samba"]["security"] = "user"
 default["samba"]["map_to_guest"] = "Bad User"
 default["samba"]["socket_options"] = "TCP_NODELAY"
+default["samba"]["shares_data_bag"] = "samba"
+default["samba"]["users_data_bag"] = "users"
 
 case platform
 when "arch"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -18,7 +18,7 @@
 #
 
 users = nil
-shares = data_bag_item("samba", "shares")
+shares = data_bag_item(node["samba"]["shares_data_bag"], "shares")
 
 shares["shares"].each do |k,v|
   if v.has_key?("path")
@@ -29,7 +29,7 @@ shares["shares"].each do |k,v|
 end
 
 unless node["samba"]["passdb_backend"] =~ /^ldapsam/
-  users = search("users", "*:*")
+  users = search(node["samba"]["users_data_bag"], "*:*")
 end
 
 package value_for_platform(


### PR DESCRIPTION
In our environment we have more than one samba server to configure. So it is necessary for us to have separate specifications for shares (and, possibly, users).

To that end I've added default attributes to specify the data bag names (they default to the original values). This allows the data bags to be changed easily.

I've updated the documentation as well.
