### PR TITLE
fix debian's samba daemon name

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -39,7 +39,8 @@ package value_for_platform(
 )
 
 svcs = value_for_platform(
-  ["ubuntu", "debian"] => { "default" => ["smbd", "nmbd"] },
+  "ubuntu" => { "default" => ["smbd", "nmbd"] },
+  "debian" => { "default" => ["samba"] },
   ["redhat", "centos", "fedora", "scientific", "amazon"] => { "default" => ["smb", "nmb"] },
   "arch" => { "default" => [ "samba" ] },
   "default" => ["smbd", "nmbd"]


### PR DESCRIPTION
Service name of Samba Server on dabian is not `smbd` and `nmbd`.
It is `samba`.

This difference cause to fail samba service starting.
So I fix it.
