### PR TITLE
Added a line to only create a user if their password is specified

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -66,6 +66,6 @@ if users
     samba_user u["id"] do
       password u["smbpasswd"]
       action [:create, :enable]
-    end
+    end if u["smbpasswd"]
   end
 end


### PR DESCRIPTION
I added this change so that samba users will only be created for some users, and not for every user in the users data bag.  
