### PR TITLE
on centos samba package is named 'samba', not samba3x

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -33,8 +33,8 @@ unless node["samba"]["passdb_backend"] =~ /^ldapsam/
 end
 
 package value_for_platform(
-  ["ubuntu", "debian", "arch"] => { "default" => "samba" },
-  ["redhat", "centos", "fedora", "scientific", "amazon"] => { "default" => "samba3x" },
+  ["ubuntu", "debian", "arch", "centos"] => { "default" => "samba" },
+  ["redhat", "fedora", "scientific", "amazon"] => { "default" => "samba3x" },
   "default" => "samba"
 )
 


### PR DESCRIPTION
probably applies to redhat, and maybe fedora, as well
but, not certain.  and, less sure about amazon 
