### PR TITLE
A minor fix for starting service on debian-based systems

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -48,6 +48,7 @@ svcs = value_for_platform(
 svcs.each do |s|
   service s do
     pattern "smbd|nmbd" if node["platform"] =~ /^arch$/
+    init_command "/usr/bin/service #{s}"
     action [:enable, :start]
   end
 end


### PR DESCRIPTION
I added this option for ubuntu system.
Without it, I can't start this service.
