### PR TITLE
Fix smbpasswd issue when creating new smbuser

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -25,7 +25,7 @@ action :create do
   unless @smbuser.exists
     pw = new_resource.password
     execute "Create #{new_resource.name}" do
-      command "echo '#{pw}\n#{pw}' | smbpasswd -s -a #{new_resource.name}"
+      command "echo '#{pw}\n#{pw}\n' | smbpasswd -s -a #{new_resource.name}"
     end
     new_resource.updated_by_last_action(true)
   end


### PR DESCRIPTION
I couldn't set the smbpasswd by creating a new samba user on a new vm. 
it took me some time, but here we go:

This was introduced when the newline was inserted by ruby, and one was left out:
SHA: 9675f54d3f46fb5122fd5bf48e2164ce645187e2
