### PR TITLE
Fix user creation to skip when no password is present

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -65,6 +65,7 @@ end
 
 if users
   users.each do |u|
+    next unless u["smbpasswd"]
     samba_user u["id"] do
       password u["smbpasswd"]
       action [:create, :enable]


### PR DESCRIPTION
Originally #5
