### PR TITLE
add attribute as alternative way to describe samba shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The attributes are used to set up the default values in the smb.conf, and set de
 * `node["samba"]["shares_data_bag"]` - the name of the data bag that contains the shares information, default "samba". See `Usage` below.
 * `node["samba"]["users_data_bag"]` - the name of the data bag that contains user details, default "users". See `Usage` below.
 * `node["samba"]["options"]` - the list of additional options, default {'unix charset' => 'UTF8'}. (optional)
+* `node['samba']['shares']` - the list contains the shares information. Used as alternative way to store shares information compare to data bag.
 
 Recipes
 =======
@@ -85,6 +86,8 @@ Usage
 The `samba::default` recipe includes `samba::client`, which simply installs smbclient package. Remaining information in this section pertains to `samba::server` recipe.
 
 Set attributes as desired in a role, and create a data bag with an item called `shares`. The default name for the data bag is `samba` but this can be changed by setting `node["samba"]["data_bag"]`. Also create a data bag with an item for each user that should have access to samba. The name of the users data bag defaults to `users` but can be changed by setting `node["samba"]["users_data_bag"]`.
+
+The alternative way to describe shares is to use attribute `node['samba']['shares']`. The `samba::server` recipe is checking if data bag `node["samba"]["data_bag"]` exists and if no, it uses `node['samba']['shares']`.
 
 Example data bag item for a single share named `export` in the `shares` item.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default['samba']['socket_options']       = 'TCP_NODELAY'
 default['samba']['shares_data_bag']      = 'samba'
 default['samba']['users_data_bag']       = 'users'
 default['samba']['options']              = {}
+default['samba']['shares']               = {}
 
 case node['platform_family']
 when 'smartos'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,9 +17,13 @@
 # limitations under the License.
 #
 
-shares = data_bag_item(node['samba']['shares_data_bag'], 'shares')
+if Chef::DataBag.list.key?(node['samba']['shares_data_bag'])
+  shares = data_bag_item(node['samba']['shares_data_bag'], 'shares')['shares']
+else
+  shares = node['samba']['shares']
+end
 
-shares['shares'].each do |k, v|
+shares.each do |k, v|
   if v.key?('path') # ~FC023
     directory v['path'] do
       recursive true
@@ -39,7 +43,7 @@ template node['samba']['config'] do
   owner 'root'
   group 'root'
   mode 00644
-  variables :shares => shares['shares']
+  variables :shares => shares
   svcs.each do |s|
     notifies :restart, "service[#{s}]"
   end


### PR DESCRIPTION
Hello,

This PR adds possibility to describe samba shares in attribute node['samba']['shares']. It's used in case when you need to store all project information (app credentials, configurations, samba shares, etc) in one data bag item and don't want to create separate data bags for shares. 
