### PR TITLE
Added options property to samba_share resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ samba_share 'Share Name' do
   valid_users # space separated users or group, default ''
   force_group # Assign Unix group as default primary, default ''
   browseable # yes, no default: yes
+  options # list of additional options, e.g. 'inherit permissions' => 'yes'
 end
 ```
 

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -29,6 +29,7 @@ property :create_mask, String, default: '0744', required: false
 property :directory_mask, String, default: '0755', required: false
 property :read_only, String, default: 'no', equal_to: %w(yes no)
 property :create_directory, [TrueClass, FalseClass], default: true
+property :options, Hash, default: {}
 property :config_file, String, default: lazy {
   if node['platform_family'] == 'smartos'
     '/opt/local/etc/samba/smb.conf'
@@ -56,6 +57,9 @@ action :add do
       variables[:shares][new_resource.share_name]['valid users'] = new_resource.valid_users
       variables[:shares][new_resource.share_name]['force group'] = new_resource.force_group
       variables[:shares][new_resource.share_name]['browseable'] = new_resource.browseable
+      new_resource.options.each do |key, value|
+        variables[:shares][new_resource.share_name][key] = value
+      end
 
       action :nothing
       delayed_action :create

--- a/test/fixtures/cookbooks/test/recipes/server.rb
+++ b/test/fixtures/cookbooks/test/recipes/server.rb
@@ -33,6 +33,7 @@ samba_share 'first_share' do
   write_list ['test_user_1']
   create_mask '0644'
   directory_mask '0775'
+  options 'inherit permissions' => 'yes'
 end
 
 samba_share 'second_share' do

--- a/test/integration/server/server_spec.rb
+++ b/test/integration/server/server_spec.rb
@@ -62,6 +62,7 @@ describe file('/etc/samba/smb.conf') do
   its('content') { should_not match(/guest_ok =/) }
   its('content') { should match(/allow dns updates = secure only/) }
   its('content') { should match(/allow insecure wide links = no/) }
+  its('content') { should match(/inherit permissions = yes/) }
 end
 
 case os['family']


### PR DESCRIPTION
This PR will allow users to specify a hash of additional options to the samba_share resource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/samba/80)
<!-- Reviewable:end -->
