### PR TITLE
readme: path required argument for samba_share

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ samba_share 'Share Name' do
   force_group # Assign Unix group as default primary, default ''
   browseable # yes, no default: yes
   options # list of additional options, e.g. 'inherit permissions' => 'yes'
+  path # String for the path of directory to be served. Required.
 end
 ```
 


### PR DESCRIPTION
Adding note in README of the required path. 

I forgot it and got an odd ValidationFailed error telling me `name is required` when it was actually the `path` I was missing. Took me a bit too long to spot this obvious error and having this line in the README would have likely shortened that debugging.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/samba/81)
<!-- Reviewable:end -->
