### PR TITLE
Delay service

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 license          'Apache-2.0'
 description      'Installs/Configures samba'
-version          '1.1.4'
+version          '1.2.0'
 source_url       'https://github.com/sous-chefs/samba'
 issues_url       'https://github.com/sous-chefs/samba/issues'
 chef_version     '>= 12.16' if respond_to?(:chef_version)

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -90,7 +90,8 @@ action :create do
         bind_interfaces_only: new_resource.bind_interfaces_only
       )
       new_resource.samba_services.each do |samba_service|
-        notifies :restart, "service[#{samba_service}]"
+        notifies :restart, "service[#{samba_service}]", :delayed
+        notifies :enable, "service[#{samba_service}]", :delayed
       end
 
       action :nothing
@@ -100,7 +101,7 @@ action :create do
     new_resource.samba_services.each do |s|
       service s do
         supports restart: true, reload: true
-        action [:enable, :start]
+        action [:nothing]
       end
     end
   end


### PR DESCRIPTION
## Description

Delays the start/restart of the service until the end of the run as the template isn't even put into place until the end of the run (for whatever reason) as it stood, the service would be started THEN the configuration put in place THEN the service restarted. No real point to that and just open the service up to a misconfiguration by default. 

### Issues Resolved

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/samba/89)
<!-- Reviewable:end -->
