### PR TITLE
Optional Args Formatting

### DIFF
--- a/templates/smb.conf.erb
+++ b/templates/smb.conf.erb
@@ -30,7 +30,7 @@
 
 <% if !@samba_options.nil? %>
   <% @samba_options.each do |opt_name,opt_value| -%>
-    <%= opt_name %> = <%= opt_value %>
+  <%= opt_name %> = <%= opt_value %>
   <% end -%>
 <% end -%>
 


### PR DESCRIPTION
## Description

This commit moves the optional args to be at the same indentation level
as the rest of the global args

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/samba/95)
<!-- Reviewable:end -->
