### PR TITLE
Cookstyle fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Add CircleCI builder
+- Remove unnecessary `if respond_to?(:chef_version)` in the metadata.rb
+- Remove unnecessary `require 'mixlib/shellout'` from the user resource
 
 ## v1.2.0 (2018-09-22)
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -25,13 +25,13 @@ def test_changes?
   false
 end
 
-fail 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
+raise 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
 
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  fail 'Please include a CHANGELOG entry.'
+  raise 'Please include a CHANGELOG entry.'
 end
 
 # A sanity check for tests.

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures samba'
 version          '1.2.0'
 source_url       'https://github.com/sous-chefs/samba'
 issues_url       'https://github.com/sous-chefs/samba/issues'
-chef_version     '>= 13.0' if respond_to?(:chef_version)
+chef_version     '>= 13.0'
 
 %w(debian ubuntu centos fedora redhat scientific amazon oracle).each do |os|
   supports os

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -31,7 +31,7 @@ property :read_only, String, default: 'no', equal_to: %w(yes no)
 property :create_directory, [TrueClass, FalseClass], default: true
 property :options, Hash, default: {}
 property :config_file, String, default: lazy {
-  if node['platform_family'] == 'smartos'
+  if node['platform_family'] == 'smartos' # rubocop: disable ChefStyle/UsePlatformHelpers
     '/opt/local/etc/samba/smb.conf'
   else
     '/etc/samba/smb.conf'

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -80,7 +80,6 @@ action :delete do
 end
 
 action_class.class_eval do
-  require 'mixlib/shellout'
   def generate_system_password
     system_password = \
       new_resource.password.crypt('$6$' + SecureRandom.random_number(36**8).to_s(36))

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,7 +1,7 @@
 name             'test'
 maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Samba test recipe'
 version          '0.1.0'
 depends          'samba'


### PR DESCRIPTION
Remove unnecessary `if respond_to?(:chef_version)` in the metadata.rb
Remove unnecessary `require 'mixlib/shellout'` from the user resource

Signed-off-by: Tim Smith <tsmith@chef.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/samba/112)
<!-- Reviewable:end -->
