### PR TITLE
add attribute "log level" to smb.conf

### DIFF
--- a/templates/smb.conf.erb
+++ b/templates/smb.conf.erb
@@ -26,6 +26,7 @@
   passdb backend = <%= @passdb_backend %>
   dns proxy = <%= @dns_proxy %>
   max log size = <%= @max_log_size %>
+  log level = <%= @log_level %>
   bind interfaces only = <%= @bind_interfaces_only %>
 
 <% if !@samba_options.nil? %>


### PR DESCRIPTION
attribute log_level gets ignored, because the options has a space instead of a "_" in it. Defined it explicitly.

# Description

Make different log levels possible. At the moment the option "log_level" gets ignored.

## Issues Resolved

## Check List
No checks were run on my side, tbh..
- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
