### PR TITLE
Remove delayed_action, action and cookbook settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Remove `delayed_action`, `action` and cookbook` settings from the share resource as these are not required
+- Remove `delayed_action`, `action` and `cookbook` settings from the share resource as these are not required
 
 ## 2.0.1 - *2021-06-01*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
+- Remove `delayed_action`, `action` and cookbook` settings from the share resource as these are not required
+
 ## 2.0.1 - *2021-06-01*
+
+- Standardise files with files in sous-chefs/repo-management
 
 ## 2.0.0 - *2021-05-11*
 

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -106,7 +106,6 @@ action :add do
   # share templates into the root context to find each other
   with_run_context :root do
     edit_resource(:template, new_resource.config_file) do |new_resource|
-      cookbook 'samba'
       variables[:shares] ||= {}
       variables[:shares][new_resource.share_name] ||= {}
       variables[:shares][new_resource.share_name]['comment'] = new_resource.comment
@@ -124,9 +123,6 @@ action :add do
       new_resource.options.each do |key, value|
         variables[:shares][new_resource.share_name][key] = value
       end
-
-      action :nothing
-      delayed_action :create
     end
   end
 


### PR DESCRIPTION
from the share resource as these are not required

Signed-off-by: Dan Webb <dan.webb@damacus.io>

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
