### PR TITLE
chore: modernize CI, Kitchen, and Ruby standards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
-      - name: Install Chef
-        uses: actionshub/chef-install@6.0.0
+      - name: Install Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@main
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:
-          CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
         with:
           suite: ${{ matrix.suite }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,16 @@ jobs:
     strategy:
       matrix:
         os:
-          - amazonlinux-2023
-          - centos-stream-8
-          - centos-stream-9
-          - debian-11
-          - debian-12
-          - fedora-latest
-          - ubuntu-2004
-          - ubuntu-2204
+          - "almalinux-8"
+          - "almalinux-9"
+          - "amazonlinux-2023"
+          - "centos-stream-9"
+          - "debian-12"
+          - "fedora-latest"
+          - "rockylinux-8"
+          - "rockylinux-9"
+          - "ubuntu-2204"
+          - "ubuntu-2404"
         suite: ["server"]
       fail-fast: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 ---
 name: release
-
 "on":
   push:
-    branches:
-      - main
+    branches: [main]
 
 permissions:
   contents: write
@@ -16,8 +14,10 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@5.0.8
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@main
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}
       supermarket_key: ${{ secrets.CHEF_SUPERMARKET_KEY }}
+      slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+require:
+  - cookstyle

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,10 +1,14 @@
 driver:
   name: dokken
   privileged: true
+  chef_image: cincproject/cinc
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  product_name: cinc
+  chef_binary: /opt/cinc/bin/cinc-client
 
 platforms:
   - name: almalinux-8

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,7 +2,7 @@ driver:
   name: dokken
   privileged: true
   chef_image: cincproject/cinc
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
 
 transport: { name: dokken }
 provisioner:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -22,35 +22,10 @@ platforms:
       image: dokken/amazonlinux-2023
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-7
-    driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-stream-8
-    driver:
-      image: dokken/centos-stream-8
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-stream-9
     driver:
       image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
-
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-
-  - name: debian-11
-    driver:
-      image: dokken/debian-11
-      pid_one_command: /bin/systemd
 
   - name: debian-12
     driver:
@@ -60,26 +35,6 @@ platforms:
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: opensuse-leap-15
-    driver:
-      image: dokken/opensuse-leap-15
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-7
-    driver:
-      image: dokken/oraclelinux-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-8
-    driver:
-      image: dokken/oraclelinux-8
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-9
-    driver:
-      image: dokken/oraclelinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: rockylinux-8
@@ -92,22 +47,12 @@ platforms:
       image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-18.04
-    driver:
-      image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
-
-  - name: ubuntu-20.04
-    driver:
-      image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
-
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
 
-  - name: ubuntu-23.04
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-23.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,14 +13,16 @@ provisioner:
   multiple_converge: 2
 
 platforms:
-  - name: amazonlinux-2
-  - name: centos-7
-  - name: centos-8
-  - name: debian-9
-  - name: debian-10
+  - name: almalinux-8
+  - name: almalinux-9
+  - name: amazonlinux-2023
+  - name: centos-stream-9
+  - name: debian-12
   - name: fedora-latest
-  - name: ubuntu-20.04
-  - name: ubuntu-21.04
+  - name: rockylinux-8
+  - name: rockylinux-9
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
   - name: server

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,8 +5,7 @@ verifier: { name: inspec }
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
-  chef_license: accept
-  product_name: chef
+  product_name: cinc
   product_version: <%= ENV['CHEF_VERSION'] || 'current' %>
   install_strategy: always
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: samba
 # Resource:: server

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: samba
 # Resource:: share

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: samba
 # Resource:: user

--- a/spec/resources/server_spec.rb
+++ b/spec/resources/server_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'samba_server' do
+  step_into :samba_server
+  platform 'ubuntu', '22.04'
+
+  context 'create action' do
+    recipe do
+      samba_server 'test-server' do
+        workgroup 'TESTGROUP'
+        interfaces 'eth0'
+        hosts_allow '10.0.0.0/8'
+      end
+    end
+
+    it { is_expected.to install_package('samba') }
+    it { is_expected.to create_template('/etc/samba/smb.conf') }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.color = true
+  config.formatter = :documentation
+  config.log_level = :warn
+  config.platform = 'ubuntu'
+  config.version = '22.04'
+end

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 name             'test'
 maintainer       'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'

--- a/test/fixtures/cookbooks/test/recipes/server.rb
+++ b/test/fixtures/cookbooks/test/recipes/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 apt_update 'update'
 
 samba_server 'foxtrot' do

--- a/test/integration/client/client_spec.rb
+++ b/test/integration/client/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe command('smbclient --help') do
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/server/server_spec.rb
+++ b/test/integration/server/server_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe port(445) do
   it { should be_listening }
 end


### PR DESCRIPTION
## Summary
- modernize the CI and Kitchen platform matrix to the currently supported Dokken targets
- switch Kitchen and workflow provisioning from Chef to Cinc/Workstation-based tooling
- add Cookstyle loading plus ChefSpec coverage for `samba_server`
- add missing `# frozen_string_literal: true` pragmas across the Ruby files touched by the cookbook and test fixtures

## Testing
- GitHub Actions
- ChefSpec for `samba_server`

## Notes
- release workflow now tracks the shared `release-cookbook` workflow on `main` and passes the Slack notification secrets expected by that workflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/samba/159)
<!-- Reviewable:end -->
