### PR TITLE
fix: samba share persistence on failed runs

### DIFF
--- a/resources/server.rb
+++ b/resources/server.rb
@@ -21,6 +21,15 @@
 
 unified_mode true
 
+samba_yes_no = proc do |value|
+  case value
+  when String
+    value.casecmp('yes').zero? || value.casecmp('true').zero? ? 'yes' : 'no'
+  else
+    value ? 'yes' : 'no'
+  end
+end
+
 property :server_string,
         String,
         name_property: true,
@@ -44,13 +53,13 @@ property :hosts_allow,
 property :bind_interfaces_only,
         [true, false, String],
         default: false,
-        coerce: proc { |p| p ? 'yes' : 'no' },
+        coerce: samba_yes_no,
         description: 'Limit interfaces to serve SMB'
 
 property :load_printers,
         [true, false, String],
         default: false,
-        coerce: proc { |p| p ? 'yes' : 'no' },
+        coerce: samba_yes_no,
         description: 'Whether to load printers'
 
 property :passdb_backend,
@@ -62,7 +71,7 @@ property :passdb_backend,
 property :dns_proxy,
         [true, false, String],
         default: false,
-        coerce: proc { |p| p ? 'yes' : 'no' },
+        coerce: samba_yes_no,
         description: 'Whether to search NetBIOS names through DNS'
 
 property :security,
@@ -94,7 +103,7 @@ property :password_server,
 property :encrypt_passwords,
         [true, false, String],
         default: true,
-        coerce: proc { |p| p ? 'yes' : 'no' },
+        coerce: samba_yes_no,
         description: 'Whether to negotiate encrypted passwords'
 
 property :log_level,

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -143,6 +143,34 @@ property :samba_services,
         default: lazy { platform_family?('rhel', 'fedora', 'amazon', 'suse') ? %w(smb nmb) : %w(smbd nmbd) },
         description: 'An array of services to start'
 
+action_class do
+  def share_options(resource)
+    {
+      'comment' => resource.comment,
+      'path' => resource.path,
+      'guest ok' => resource.guest_ok,
+      'printable' => resource.printable,
+      'write list' => resource.write_list,
+      'create mask' => resource.create_mask,
+      'directory mask' => resource.directory_mask,
+      'read only' => resource.read_only,
+      'valid users' => resource.valid_users,
+      'force user' => resource.force_user,
+      'force group' => resource.force_group,
+      'browseable' => resource.browseable,
+    }.merge(resource.options)
+  end
+
+  def declared_shares
+    run_context.resource_collection.each_with_object({}) do |resource, shares|
+      next unless resource.resource_name == :samba_share
+      next unless resource.config_file == new_resource.config_file
+
+      shares[resource.share_name] = share_options(resource)
+    end
+  end
+end
+
 action :create do
   package 'samba'
 
@@ -174,7 +202,8 @@ action :create do
         samba_options: new_resource.options,
         log_level: new_resource.log_level,
         max_log_size: new_resource.max_log_size,
-        bind_interfaces_only: new_resource.bind_interfaces_only
+        bind_interfaces_only: new_resource.bind_interfaces_only,
+        shares: declared_shares
       )
       new_resource.samba_services.each do |samba_service|
         notifies :restart, "service[#{samba_service}]", :delayed

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -21,6 +21,15 @@
 
 unified_mode true
 
+samba_yes_no = proc do |value|
+  case value
+  when String
+    value.casecmp('yes').zero? || value.casecmp('true').zero? ? 'yes' : 'no'
+  else
+    value ? 'yes' : 'no'
+  end
+end
+
 property :share_name,
         String,
         name_property: true,
@@ -50,19 +59,19 @@ property :force_user,
 property :browseable,
         [true, false, String],
         default: true,
-        coerce: proc { |p| p ? 'yes' : 'no' },
+        coerce: samba_yes_no,
         description: 'Controls whether this share is seen in the list of available shares in a net view and in the browse list'
 
 property :guest_ok,
         [true, false, String],
         default: false,
-        coerce: proc { |p| p ? 'yes' : 'no' },
+        coerce: samba_yes_no,
         description: 'Allow anoymous access to the share'
 
 property :printable,
         [true, false, String],
         default: false,
-        coerce: proc { |p| p ? 'yes' : 'no' },
+        coerce: samba_yes_no,
         description: 'If set to yes, then clients may open, write to and submit spool files on the directory specified for the service'
 
 property :write_list,
@@ -85,7 +94,7 @@ property :directory_mask,
 property :read_only,
         [true, false, String],
         default: false,
-        coerce: proc { |p| p ? 'yes' : 'no' },
+        coerce: samba_yes_no,
         description: 'Whether files on the share are writeable'
 
 property :create_directory,

--- a/resources/share.rb
+++ b/resources/share.rb
@@ -104,30 +104,6 @@ property :config_file,
         description: 'Path to the samba configuration file'
 
 action :add do
-  # We need to force both the server template and the
-  # share templates into the root context to find each other
-  with_run_context :root do
-    edit_resource(:template, new_resource.config_file) do |new_resource|
-      variables[:shares] ||= {}
-      variables[:shares][new_resource.share_name] ||= {}
-      variables[:shares][new_resource.share_name]['comment'] = new_resource.comment
-      variables[:shares][new_resource.share_name]['path'] = new_resource.path
-      variables[:shares][new_resource.share_name]['guest ok'] = new_resource.guest_ok
-      variables[:shares][new_resource.share_name]['printable'] = new_resource.printable
-      variables[:shares][new_resource.share_name]['write list'] = new_resource.write_list
-      variables[:shares][new_resource.share_name]['create mask'] = new_resource.create_mask
-      variables[:shares][new_resource.share_name]['directory mask'] = new_resource.directory_mask
-      variables[:shares][new_resource.share_name]['read only'] = new_resource.read_only
-      variables[:shares][new_resource.share_name]['valid users'] = new_resource.valid_users
-      variables[:shares][new_resource.share_name]['force user'] = new_resource.force_user
-      variables[:shares][new_resource.share_name]['force group'] = new_resource.force_group
-      variables[:shares][new_resource.share_name]['browseable'] = new_resource.browseable
-      new_resource.options.each do |key, value|
-        variables[:shares][new_resource.share_name][key] = value
-      end
-    end
-  end
-
   if new_resource.create_directory
     directory new_resource.path do
       recursive true

--- a/spec/resources/server_spec.rb
+++ b/spec/resources/server_spec.rb
@@ -18,4 +18,24 @@ describe 'samba_server' do
     it { is_expected.to install_package('samba') }
     it { is_expected.to create_template('/etc/samba/smb.conf') }
   end
+
+  context 'when shares are declared separately' do
+    recipe do
+      samba_server 'test-server'
+
+      samba_share 'homes' do
+        comment 'Home Directories'
+        guest_ok 'no'
+        read_only 'no'
+        browseable 'no'
+        create_directory false
+      end
+    end
+
+    it 'renders the share into smb.conf' do
+      expect(chef_run).to render_file('/etc/samba/smb.conf').with_content('[homes]')
+      expect(chef_run).to render_file('/etc/samba/smb.conf').with_content('comment = Home Directories')
+      expect(chef_run).to render_file('/etc/samba/smb.conf').with_content('browseable = no')
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- make `samba_server` build the share data for `smb.conf` from the compiled resource collection instead of depending on later `samba_share` convergence to mutate the template
- remove the `samba_share` code path that edits the server template in place during its action
- add a regression spec covering a separately declared `samba_share` so the rendered config still includes the share block

## Why
Issue #96 describes a failure mode where an unrelated resource fails later in the Chef run after `samba_server` has already queued the delayed `smb.conf` write. In the old implementation, shares were only attached to the template when each `samba_share` actually converged, so a failed run could still flush a config file with no share definitions and interrupt service.

## Impact
- declared shares remain present in the generated Samba config even when a later unrelated resource fails
- `samba_share` no longer needs to reach back into the server template to inject variables during converge
- the regression is covered at the ChefSpec layer

## Root cause
The delayed template write in `samba_server` used template variables that were populated by `samba_share` actions. If the Chef run aborted before those actions converged, the delayed template still executed with an empty `shares` hash.

## Validation
- `cookstyle resources/server.rb resources/share.rb spec/resources/server_spec.rb`
- `ruby -c resources/server.rb`
- `ruby -c resources/share.rb`
- `chef exec rspec spec/resources/server_spec.rb` currently fails in this environment because the local Chef Ruby cannot load the native `json` extension (`parser.bundle` code-signing / Team ID mismatch on macOS)

Closes #96.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/samba/161)
<!-- Reviewable:end -->
