### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/fixtures/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+name 'samba'
+
+run_list 'test::server'
+
+cookbook 'samba', path: '.'
+cookbook 'test', path: 'test/fixtures/cookbooks/test'

--- a/chefignore
+++ b/chefignore
@@ -83,23 +83,11 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*
 Gemfile
 Gemfile.lock
-
-# Policyfile #
-##############
-Policyfile.rb
-Policyfile.lock.json
 
 # Documentation #
 #############

--- a/documentation/samba_server.md
+++ b/documentation/samba_server.md
@@ -18,7 +18,7 @@ Installs and configures Samba server
 | kerberos_method      | `String`            | `'secrets only'`        | See resource for full list               | How kerberos tickets are verified                                      |
 | password_server      | `String`            | `'*'`                   |                                          | Use a specific remote server for auth                                  |
 | encrypt_passwords    | `true`, `false`     | `true`                  | `true false`                             | Whether to negotiate encrypted passwords                               |
-| log_level            | `String`, `Integer` | `'0'`                   |                                          | Sets the logging level from 0-10                                      |
+| log_level            | `String`, `Integer` | `'0'`                   |                                          | Sets the logging level from 0-10                                       |
 | winbind_separator    | `String`            | `\`                     |                                          | The character used when listing a username of the form of DOMAIN \user |
 | idmap_config         | `String`            |                         |                                          | Define the mapping between SIDS and Unix users and groups              |
 | socket_options       | `String`, `Integer` | 'TCP_NODELAY'           | See resource for full list               | Options for connection tuning                                          |

--- a/documentation/samba_user.md
+++ b/documentation/samba_user.md
@@ -14,13 +14,13 @@ This will enforce the user system password set by the resource.
 
 ## Properties
 
-| Name        | Type                                 | Default     | Description                                         |
-| ----------- | ------------------------------------ | ----------- | --------------------------------------------------- |
-| password    | `String`                             |             | User password for samba and the system              |
-| comment     | `String`                             |             | One (or more) comments about the user               |
-| home        | `String`                             | `::File.join('/home/', name)` | Users home                        |
-| shell       | `String`                             | `/bin/bash` | User shell to set                                   |
-| manage_home | `true`, `false`                      | `true`      | Whether to manage the users home directory location |
+| Name        | Type                                 | Default                       | Description                                         |
+| ----------- | ------------------------------------ | ----------------------------- | --------------------------------------------------- |
+| password    | `String`                             |                               | User password for samba and the system              |
+| comment     | `String`                             |                               | One (or more) comments about the user               |
+| home        | `String`                             | `::File.join('/home/', name)` | Users home                                          |
+| shell       | `String`                             | `/bin/bash`                   | User shell to set                                   |
+| manage_home | `true`, `false`                      | `true`                        | Whether to manage the users home directory location |
 
 ## Examples
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,11 @@ source_url       'https://github.com/sous-chefs/samba'
 issues_url       'https://github.com/sous-chefs/samba/issues'
 chef_version     '>= 15.3'
 
-%w(debian ubuntu centos fedora redhat scientific amazon oracle).each do |os|
-  supports os
-end
+supports 'debian'
+supports 'ubuntu'
+supports 'centos'
+supports 'fedora'
+supports 'redhat'
+supports 'scientific'
+supports 'amazon'
+supports 'oracle'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary

* add `Policyfile.rb` for `test::server`
* remove `Berksfile`
* switch ChefSpec from Berkshelf to Policyfile support
* stop excluding Berkshelf and Policyfile files from cookbook packaging
* fix two existing markdown table alignment issues required for the markdownlint gate

## Local verification

* `chef install Policyfile.rb`
* `cookstyle --no-server --cache-root /private/tmp/rubocop_cache`
* `/opt/homebrew/bin/markdownlint-cli2 "**/*.md"`
* `env GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec`
* `git diff --check`
* `kitchen list`
* `env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/samba/170)
<!-- Reviewable:end -->
